### PR TITLE
Feature(task): task 아이템 draggable

### DIFF
--- a/todokeep-api/src/boards/boards.controller.ts
+++ b/todokeep-api/src/boards/boards.controller.ts
@@ -33,7 +33,10 @@ export class BoardsController {
   update(@Param('id') id: string, @Body('title') title: string) {
     return this.boardService.update(id, title);
   }
-
+  @Put(':id/reorder')
+  reorder(@Param('id') id: string, @Body('taskIds') taskIds: string[]) {
+    return this.boardService.reorderTasks(id, taskIds);
+  }
   @Delete(':id')
   delete(@Param('id') id: string) {
     return this.boardService.delete(id);

--- a/todokeep-api/src/boards/boards.service.ts
+++ b/todokeep-api/src/boards/boards.service.ts
@@ -22,6 +22,7 @@ export class BoardsService {
       .find({
         boardId,
       })
+      .sort({ order: 1 }) // Sort by order field
       .exec();
 
     return { ...board.toObject(), tasks };
@@ -54,5 +55,17 @@ export class BoardsService {
 
     // 3. Emit event (optional)
     this.eventEmitter.emit('board.delete', id);
+  }
+
+  async reorderTasks(boardId: string, taskIds: string[]) {
+    // Update order for each task
+    const updatePromises = taskIds.map((taskId, index) =>
+      this.taskModel.findByIdAndUpdate(taskId, { order: index }).exec(),
+    );
+
+    await Promise.all(updatePromises);
+
+    // Return updated tasks
+    return this.taskModel.find({ boardId }).sort({ order: 1 }).exec();
   }
 }

--- a/todokeep-api/src/socket/events.gateway.ts
+++ b/todokeep-api/src/socket/events.gateway.ts
@@ -43,6 +43,15 @@ export class EventsGateway {
     client.join(boardId);
     console.log(`Client ${client.id} joined board ${boardId}`);
   }
+  // Example handler for leaving board room
+  @SubscribeMessage('leave-board')
+  handleLeaveBoard(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() boardId: string,
+  ) {
+    client.leave(boardId);
+    console.log(`Client ${client.id} left board ${boardId}`);
+  }
 
   // Handle client-side message: socket.emit('board.new', data)
   @OnEvent('board.new')
@@ -81,5 +90,16 @@ export class EventsGateway {
   @OnEvent('task.delete')
   handleTaskDelete(@MessageBody() id: string): void {
     this.server.emit('task:delete', id);
+  }
+
+  // Handle task reorder from client
+  @SubscribeMessage('task:reorder')
+  handleTaskReorderFromClient(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() data: { boardId: string; tasks: any[] },
+  ) {
+    // Broadcast to all clients in the same board room except sender
+    client.to(data.boardId).emit('task:reorder', data.tasks);
+    console.log(`Task reordered in board ${data.boardId}`);
   }
 }

--- a/todokeep-api/src/tasks/task.schema.ts
+++ b/todokeep-api/src/tasks/task.schema.ts
@@ -9,12 +9,16 @@ export class Task {
   @Prop()
   content: string;
 
-  @Prop()
+  @Prop({ default: false })
   completed: boolean;
 
   // Reference to Board
   @Prop()
   boardId: string; // This links Task -> Board
+
+  // Order for drag and drop
+  @Prop({ default: 0 })
+  order: number;
 }
 
 export type TaskDocument = Task & Document;

--- a/todokeep-nextjs/package.json
+++ b/todokeep-nextjs/package.json
@@ -9,8 +9,12 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^7.3.2",
     "@mui/material": "^7.3.2",
     "next": "15.3.4",
     "react": "^19.0.0",

--- a/todokeep-nextjs/pnpm-lock.yaml
+++ b/todokeep-nextjs/pnpm-lock.yaml
@@ -8,12 +8,24 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.1.1)
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@19.1.13)(react@19.1.1)
       '@emotion/styled':
         specifier: ^11.14.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1)
+      '@mui/icons-material':
+        specifier: ^7.3.2
+        version: 7.3.2(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react@19.1.1)
       '@mui/material':
         specifier: ^7.3.2
         version: 7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -108,6 +120,28 @@ packages:
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@1.5.0':
     resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
@@ -370,6 +404,17 @@ packages:
 
   '@mui/core-downloads-tracker@7.3.2':
     resolution: {integrity: sha512-AOyfHjyDKVPGJJFtxOlept3EYEdLoar/RvssBTWVAvDJGIE676dLi2oT/Kx+FoVXFoA/JdV7DEMq/BVWV3KHRw==}
+
+  '@mui/icons-material@7.3.2':
+    resolution: {integrity: sha512-TZWazBjWXBjR6iGcNkbKklnwodcwj0SrChCNHc9BhD9rBgET22J1eFhHsEmvSvru9+opDy3umqAimQjokhfJlQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@mui/material': ^7.3.2
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@mui/material@7.3.2':
     resolution: {integrity: sha512-qXvbnawQhqUVfH1LMgMaiytP+ZpGoYhnGl7yYq2x57GYzcFL/iPzSZ3L30tlbwEjSVKNYcbiKO8tANR1tadjUg==}
@@ -2181,6 +2226,31 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
+  '@dnd-kit/accessibility@3.1.1(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.1.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.1)
+      react: 19.1.1
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+      tslib: 2.8.1
+
   '@emnapi/core@1.5.0':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
@@ -2445,6 +2515,14 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@mui/core-downloads-tracker@7.3.2': {}
+
+  '@mui/icons-material@7.3.2(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@mui/material': 7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.13
 
   '@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react@19.1.1))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:

--- a/todokeep-nextjs/src/component/SortableTask/sortableTask.tsx
+++ b/todokeep-nextjs/src/component/SortableTask/sortableTask.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Checkbox,
+  CircularProgress,
+  Container,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Typography,
+  Alert,
+  Divider,
+  TextField,
+  IconButton,
+} from "@mui/material";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import socket from "@/lib/socket";
+import { useParams } from "next/navigation";
+
+interface Task {
+  _id: string;
+  title: string;
+  completed: boolean;
+  boardId: string;
+}
+
+function SortableTask({
+  task,
+  editingTaskId,
+  editingTitle,
+  setEditingTaskId,
+  setEditingTitle,
+  toggleComplete,
+  updateTaskTitle,
+}: {
+  task: Task;
+  editingTaskId: string | null;
+  editingTitle: string;
+  setEditingTaskId: (id: string | null) => void;
+  setEditingTitle: (title: string) => void;
+  toggleComplete: (task: Task) => void;
+  updateTaskTitle: (task: Task, title: string) => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: task._id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <ListItem
+      ref={setNodeRef}
+      style={style}
+      disablePadding
+      secondaryAction={
+        <IconButton edge="end" {...attributes} {...listeners}>
+          <DragIndicatorIcon />
+        </IconButton>
+      }
+    >
+      <ListItemIcon>
+        <Checkbox
+          edge="start"
+          checked={Boolean(task.completed)}
+          onChange={() => toggleComplete(task)}
+        />
+      </ListItemIcon>
+
+      {editingTaskId === task._id ? (
+        <TextField
+          value={editingTitle}
+          onChange={(e) => setEditingTitle(e.target.value)}
+          onBlur={() => {
+            updateTaskTitle(task, editingTitle);
+            setEditingTaskId(null);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              updateTaskTitle(task, editingTitle);
+              setEditingTaskId(null);
+            }
+          }}
+          size="small"
+          fullWidth
+          autoFocus
+        />
+      ) : (
+        <ListItemText
+          primary={task.title}
+          secondary={task._id}
+          onClick={() => {
+            setEditingTaskId(task._id);
+            setEditingTitle(task.title ?? "");
+          }}
+          sx={{
+            textDecoration: task.completed ? "line-through" : "none",
+            cursor: "pointer",
+          }}
+        />
+      )}
+    </ListItem>
+  );
+}
+
+export default SortableTask;


### PR DESCRIPTION
### 작동 방식

1. 프론트엔드에서 드래그 완료 → socket.emit('task:reorder', { boardId, tasks })
2. 백엔드 Gateway가 이벤트 수신 → 같은 room의 다른 클라이언트에 브로드캐스트
3. 다른 클라이언트들이 task:reorder 이벤트 수신 → UI 업데이트
4. PUT /api/boards/:id/reorder 호출 → DB에 순서 영구 저장

### BE 작업 내용

1. events.gateway.ts

task:reorder 소켓 이벤트 리스너 추가
같은 board room의 다른 클라이언트들에게 순서 변경 브로드캐스트
leave-board 이벤트 핸들러 추가

2. task.schema.ts

order 필드 추가 (기본값: 0)
드래그 앤 드롭 순서를 DB에 영구 저장

3. boards.controller.ts

PUT /api/boards/:id/reorder 엔드포인트 추가
taskIds 배열을 받아서 순서 업데이트

4. boards.service.ts

reorderTasks() 메서드 추가
getBoardWithTasks()에서 order 필드로 정렬
여러 task의 order를 한 번에 업데이트

### FE 작업 내용
@dnd-kit/sortable 사용 - 최신 React와 Next.js 15와 완벽히 호환
분리된 정렬 - 미완료/완료 태스크를 각각 독립적으로 드래그 가능
실시간 동기화 - Socket.io로 task:reorder 이벤트 발생
드래그 핸들 - 우측 아이콘을 통해 드래그 가능
키보드 접근성 - 키보드로도 순서 변경 가능

### 사용자가 키보드로 순서를 변경하는 방법:
1. Tab 키 - 드래그 핸들(아이콘)로 포커스 이동
2. Space 또는 Enter - 드래그 모드 활성화
3. 방향키 (↑↓) - 아이템을 위/아래로 이동
4. Space 또는 Enter - 새 위치에 드롭
5. Esc - 드래그 취소